### PR TITLE
シール構造のリファクタ

### DIFF
--- a/src/matsu/num/matrix/core/DiagonalMatrix.java
+++ b/src/matsu/num/matrix/core/DiagonalMatrix.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.11
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
@@ -45,7 +45,7 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  */
 public sealed interface DiagonalMatrix
         extends BandMatrix, Symmetric, Invertible, Determinantable
-        permits DiagonalMatrixSealed {
+        permits DiagonalMatrixSealed, SignatureMatrix, SquareZeroMatrix {
 
     @Override
     public abstract Optional<? extends DiagonalMatrix> inverse();

--- a/src/matsu/num/matrix/core/DiagonalMatrix.java
+++ b/src/matsu/num/matrix/core/DiagonalMatrix.java
@@ -38,6 +38,13 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * ({@link Symmetric}, {@link Invertible}, {@link Determinantable})
  * が追加されている.
  * </p>
+ * 
+ * <p>
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
+ * </p>
  *
  * @author Matsuura Y.
  * @see <a href="https://en.wikipedia.org/wiki/Diagonal_matrix">

--- a/src/matsu/num/matrix/core/LowerUnitriangular.java
+++ b/src/matsu/num/matrix/core/LowerUnitriangular.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.11
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
@@ -26,7 +26,10 @@ import java.util.Optional;
  * </p>
  *
  * <p>
- * 実装においては, {@link EntryReadableMatrix} のクラス説明の規約に従う.
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
  * </p>
  *
  * @author Matsuura Y.

--- a/src/matsu/num/matrix/core/PermutationMatrix.java
+++ b/src/matsu/num/matrix/core/PermutationMatrix.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.1.17
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
@@ -43,8 +43,9 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * @see <a href="https://en.wikipedia.org/wiki/Permutation_matrix">
  *          Permutation matrix</a>
  */
-public sealed interface PermutationMatrix extends EntryReadableMatrix,
-        OrthogonalMatrix, Determinantable permits PermutationMatrixSealed {
+public sealed interface PermutationMatrix
+        extends EntryReadableMatrix, OrthogonalMatrix, Determinantable
+        permits PermutationMatrixSealed, UnitMatrix {
 
     /**
      * 置換の偶奇を取得する.

--- a/src/matsu/num/matrix/core/PermutationMatrix.java
+++ b/src/matsu/num/matrix/core/PermutationMatrix.java
@@ -38,6 +38,13 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * このインターフェースの実装クラスのインスタンスは,
  * ビルダ ({@link PermutationMatrix.Builder}) を用いて生成する.
  * </p>
+ * 
+ * <p>
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
+ * </p>
  *
  * @author Matsuura Y.
  * @see <a href="https://en.wikipedia.org/wiki/Permutation_matrix">

--- a/src/matsu/num/matrix/core/SignatureMatrix.java
+++ b/src/matsu/num/matrix/core/SignatureMatrix.java
@@ -22,7 +22,7 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * <p>
  * Signature matrix とは, 対角成分が1または-1の対角行列である. <br>
  * よって, 対称行列かつ直交行列である. <br>
- * 対角成分の-1の個数が奇数のときは行列式は-1であり, 
+ * 対角成分の-1の個数が奇数のときは行列式は-1であり,
  * 対角成分の-1の個数が偶数のときは行列式は1である. <br>
  * 対角成分の-1の個数の偶奇は {@link #isEven()} により判定可能である.
  * </p>
@@ -30,6 +30,13 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * <p>
  * このインターフェースの実装クラスのインスタンスは,
  * ビルダ ({@link SignatureMatrix.Builder}) を用いて生成する.
+ * </p>
+ * 
+ * <p>
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
  * </p>
  * 
  * @author Matsuura Y.

--- a/src/matsu/num/matrix/core/SignatureMatrix.java
+++ b/src/matsu/num/matrix/core/SignatureMatrix.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.1.17
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import matsu.num.matrix.core.helper.value.BandDimensionPositionState;
-import matsu.num.matrix.core.sealed.DiagonalMatrixSealed;
 import matsu.num.matrix.core.sealed.SignatureMatrixSealed;
 import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
 
@@ -36,8 +35,8 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * @author Matsuura Y.
  */
 public sealed interface SignatureMatrix
-        extends DiagonalMatrixSealed, OrthogonalMatrix
-        permits SignatureMatrixSealed {
+        extends DiagonalMatrix, OrthogonalMatrix
+        permits SignatureMatrixSealed, UnitMatrix {
 
     @Override
     public abstract SignatureMatrix transpose();

--- a/src/matsu/num/matrix/core/SquareZeroMatrix.java
+++ b/src/matsu/num/matrix/core/SquareZeroMatrix.java
@@ -5,14 +5,12 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.1.18
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
 import java.util.Optional;
 
-import matsu.num.matrix.core.sealed.DiagonalMatrixSealed;
-import matsu.num.matrix.core.sealed.ZeroMatrixSealed;
 import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
 
 /**
@@ -27,7 +25,7 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  */
 public final class SquareZeroMatrix
         extends SkeletalSymmetricMatrix<SquareZeroMatrix>
-        implements ZeroMatrixSealed, DiagonalMatrixSealed {
+        implements ZeroMatrix, DiagonalMatrix {
 
     private final BandMatrixDimension bandMatrixDimension;
     private final Vector zeroVector;

--- a/src/matsu/num/matrix/core/UnitMatrix.java
+++ b/src/matsu/num/matrix/core/UnitMatrix.java
@@ -5,13 +5,11 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.26
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
 import matsu.num.matrix.core.helper.value.BandDimensionPositionState;
-import matsu.num.matrix.core.sealed.PermutationMatrixSealed;
-import matsu.num.matrix.core.sealed.SignatureMatrixSealed;
 import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
 
 /**
@@ -26,7 +24,7 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  */
 public final class UnitMatrix
         extends SkeletalSymmetricOrthogonalMatrix<UnitMatrix>
-        implements SignatureMatrixSealed, PermutationMatrixSealed, LowerUnitriangular {
+        implements SignatureMatrix, PermutationMatrix, LowerUnitriangular {
 
     private final BandMatrixDimension bandMatrixDimension;
 

--- a/src/matsu/num/matrix/core/ZeroMatrix.java
+++ b/src/matsu/num/matrix/core/ZeroMatrix.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.11
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
@@ -29,7 +29,7 @@ import matsu.num.matrix.core.sealed.ZeroMatrixSealed;
  * @author Matsuura Y.
  */
 public sealed interface ZeroMatrix extends EntryReadableMatrix
-        permits ZeroMatrixSealed {
+        permits SquareZeroMatrix, ZeroMatrixImpl, ZeroMatrixSealed {
 
     @Override
     public abstract ZeroMatrix transpose();

--- a/src/matsu/num/matrix/core/ZeroMatrix.java
+++ b/src/matsu/num/matrix/core/ZeroMatrix.java
@@ -26,6 +26,13 @@ import matsu.num.matrix.core.sealed.ZeroMatrixSealed;
  * {@link SquareZeroMatrix} 型で扱うべきである.
  * </p>
  * 
+ * <p>
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
+ * </p>
+ * 
  * @author Matsuura Y.
  */
 public sealed interface ZeroMatrix extends EntryReadableMatrix

--- a/src/matsu/num/matrix/core/ZeroMatrixImpl.java
+++ b/src/matsu/num/matrix/core/ZeroMatrixImpl.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.1.18
+ * 2025.1.20
  */
 package matsu.num.matrix.core;
 
@@ -17,8 +17,8 @@ import matsu.num.matrix.core.validation.MatrixFormatMismatchException;
  * 
  * @author Matsuura Y.
  */
-final class ZeroMatrixImpl extends SkeletalAsymmetricMatrix<ZeroMatrix>
-        implements ZeroMatrixSealed {
+final class ZeroMatrixImpl
+        extends SkeletalAsymmetricMatrix<ZeroMatrix> implements ZeroMatrix {
 
     private final MatrixDimension matrixDimension;
     private final Vector operatedVector;

--- a/src/matsu/num/matrix/core/nlsf/LUTypeSolver.java
+++ b/src/matsu/num/matrix/core/nlsf/LUTypeSolver.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.2
+ * 2025.1.20
  */
 package matsu.num.matrix.core.nlsf;
 
@@ -35,6 +35,13 @@ import matsu.num.matrix.core.Inversion;
  * 
  * <p>
  * {@link Inversion}, {@link Determinantable} の規約に従う.
+ * </p>
+ * 
+ * <p>
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
  * </p>
  * 
  * @author Matsuura Y.

--- a/src/matsu/num/matrix/core/nlsf/SolvingFactorizationExecutor.java
+++ b/src/matsu/num/matrix/core/nlsf/SolvingFactorizationExecutor.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.17
+ * 2025.1.20
  */
 package matsu.num.matrix.core.nlsf;
 
@@ -73,8 +73,9 @@ import matsu.num.matrix.core.validation.MatrixStructureAcceptance;
  * </p>
  * 
  * <p>
- * <u><i>このインターフェースは実装を隠ぺいして型を公開するためのものである. <br>
- * モジュール外での実装は不可.
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
  * </i></u>
  * </p>
  * 

--- a/src/matsu/num/matrix/core/nlsf/SymmetrizedSquareTypeSolver.java
+++ b/src/matsu/num/matrix/core/nlsf/SymmetrizedSquareTypeSolver.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2024.12.2
+ * 2025.1.20
  */
 package matsu.num.matrix.core.nlsf;
 
@@ -49,6 +49,13 @@ import matsu.num.matrix.core.Symmetric;
  * {@link #target()} によって返される行列 A,
  * {@link #inverse()} によって返される行列 A<sup>-1</sup> には,
  * {@link Symmetric} が付与されていなければならない.
+ * </p>
+ * 
+ * <p>
+ * <u><i>
+ * このインターフェースは主に, 戻り値型を公開するために用意されており,
+ * モジュール外での実装は想定されていない.
+ * </i></u>
  * </p>
  * 
  * @author Matsuura Y.


### PR DESCRIPTION
# シール構造のリファクタ

## 動機
モジュールシステム下では, javadocの生成は公開パッケージのみを行う.
このとき, 非公開パッケージに用意されたコンポーネントを公開パッケージで継承・実装すると, 
生成されたjavadocで非公開パッケージのコンポーネントが漏洩する.

既存のコードでは

  - 非公開パッケージに用意されたインターフェース or クラスをpermits
  - 公開パッケージでそれを継承・実装

となっており, この漏洩に引っかかっていた.

## 実施
### 主な内容
漏洩を回避するため, 公開要素へのpermitsは非公開パッケージを経由せずに直接行うように変更する.

### 関連する軽微な変更
モジュール外で実装してはいけない旨を, インターフェースに記載する.