### PR TITLE
refactor: LowerUnitriangularをシールする

### DIFF
--- a/src/matsu/num/matrix/core/LowerUnitriangular.java
+++ b/src/matsu/num/matrix/core/LowerUnitriangular.java
@@ -11,6 +11,8 @@ package matsu.num.matrix.core;
 
 import java.util.Optional;
 
+import matsu.num.matrix.core.sealed.LowerUnitriangularSealed;
+
 /**
  * 成分にアクセス可能な単位下三角行列を表す.
  * 
@@ -36,8 +38,9 @@ import java.util.Optional;
  * @see EntryReadableMatrix
  * @see Invertible
  */
-public interface LowerUnitriangular
-        extends EntryReadableMatrix, Invertible, Determinantable {
+public sealed interface LowerUnitriangular
+        extends EntryReadableMatrix, Invertible, Determinantable
+        permits LowerUnitriangularMatrix, LowerUnitriangularBandMatrix, UnitMatrix, LowerUnitriangularSealed {
 
     /**
      * 逆行列を取得する. <br>

--- a/src/matsu/num/matrix/core/sealed/LowerUnitriangularSealed.java
+++ b/src/matsu/num/matrix/core/sealed/LowerUnitriangularSealed.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2025 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+
+/*
+ * 2025.1.20
+ */
+package matsu.num.matrix.core.sealed;
+
+import matsu.num.matrix.core.LowerUnitriangular;
+
+/**
+ * {@link LowerUnitriangular} の実装をこのモジュール内に制限するためのヘルパーインターフェース. <br>
+ * {@link LowerUnitriangular} の実装を不可視なクラスで実現するため,
+ * 非公開パッケージで継承先を定義する.
+ * 
+ * <p>
+ * このインターフェースはおそらく実装されない. <br>
+ * シールが"網羅的"にならないように用意する.
+ * </p>
+ * 
+ * @author Matsuura Y.
+ */
+public non-sealed interface LowerUnitriangularSealed extends LowerUnitriangular {
+
+}


### PR DESCRIPTION
LowerUnitriangularはモジュール外での継承が想定されていないので, シールインターフェースに変更する.