### PR TITLE
fix: SignatureMatrix.operateが引数を書き換えるバグを修正

### DIFF
--- a/src/matsu/num/matrix/core/SignatureMatrix.java
+++ b/src/matsu/num/matrix/core/SignatureMatrix.java
@@ -313,7 +313,7 @@ public sealed interface SignatureMatrix
                                     bandMatrixDimension, vectorDimension));
                 }
 
-                final double[] entry = operand.entry();
+                final double[] entry = operand.entryAsArray();
 
                 final int dimension = vectorDimension.intValue();
                 for (int i = 0; i < dimension; i++) {

--- a/test/matsu/num/matrix/core/SignatureMatrixTest.java
+++ b/test/matsu/num/matrix/core/SignatureMatrixTest.java
@@ -158,6 +158,15 @@ final class SignatureMatrixTest {
                         result[i], is(expected[i]));
             }
         }
+
+        @Test
+        public void test_右辺ベクトルが変更されないことを確認する() {
+
+            double[] rightEntryClone = right.entryAsArray();
+            m.operate(right);
+
+            assertThat(right.entryAsArray(), is(rightEntryClone));
+        }
     }
 
     public static class toString表示 {


### PR DESCRIPTION
# fix: SignatureMatrix.operateが引数を書き換えるバグを修正

## バグの内容
SignatureMatrix.operateが内部でVector.entry()を呼び, さらに書き換えを行っていた.
Vector.entry()はVectorインスタンス内部の配列への参照を返すため, 書き換えを行うとVectorのイミュータブルが破壊される.

## 修正内容
Vector.entryAsArray()を呼ぶように修正する.